### PR TITLE
Added basic bash completion

### DIFF
--- a/fbcmd-completion.bash
+++ b/fbcmd-completion.bash
@@ -1,6 +1,7 @@
 # bash completion for fbcmd
 
 fbcmd_commands=$(fbcmd BC_COMMANDS)
+fbcmd_preferences=$(fbcmd BC_PREFERENCES)
 
 _fbcmd() {
 
@@ -8,7 +9,12 @@ _fbcmd() {
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-  COMPREPLY=( $(compgen -W "${fbcmd_commands}" -- $cur) )
+  if [[ "$cur" == -* ]] ; then
+    COMPREPLY=( $(compgen -W "${fbcmd_preferences}" -- $cur) )
+  else
+    COMPREPLY=( $(compgen -W "${fbcmd_commands}" -- $cur) )
+  fi
+
   return 0
 
 }

--- a/fbcmd-completion.bash
+++ b/fbcmd-completion.bash
@@ -1,0 +1,16 @@
+# bash completion for fbcmd
+
+fbcmd_commands=$(fbcmd BC_COMMANDS)
+
+_fbcmd() {
+
+  local cur prev
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  COMPREPLY=( $(compgen -W "${fbcmd_commands}" -- $cur) )
+  return 0
+
+}
+
+complete -F _fbcmd fbcmd

--- a/fbcmd.php
+++ b/fbcmd.php
@@ -316,6 +316,14 @@
     $fbcmdPrefs[$key] = str_replace('[datadir]',$fbcmdBaseDir,$value);
   }
 
+  if ($fbcmdCommand == 'BC_PREFERENCES') {
+    foreach (array_keys($fbcmdPrefs) as $pref) {
+      $pref = strtolower( $pref );
+      print "-$pref ";
+    }
+    return;
+  }
+
 ////////////////////////////////////////////////////////////////////////////////
 
   if ($fbcmdCommand == 'SAVEPREF') {

--- a/fbcmd.php
+++ b/fbcmd.php
@@ -408,6 +408,16 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
+  if ($fbcmdCommand == 'BC_COMMANDS') {
+    foreach ($fbcmdCommandList as $cmd) {
+      $cmd = strtolower( $cmd );
+      print "$cmd ";
+    }
+    return;
+  }
+
+////////////////////////////////////////////////////////////////////////////////
+
   if (in_array($fbcmdCommand,array('DFILE','FEED','FEED3','FSTATUSID','FLSTATUS','PICS'))) {
     FbcmdFatalError("{$fbcmdCommand} has been deprecated:\n  visit http://fbcmd.dtompkins.com/commands/" . strtolower($fbcmdCommand) . " for more information");
   }


### PR DESCRIPTION
I added a function in the fbcmd.php file to dump the available commands in a format that can be used in a bash completion function.

I also added a bash completion script you can put in your .bash_completion.d directory.  It only handles the 'command' portion of fbcmd, but its a start.
